### PR TITLE
Add signing rewritten assemblies

### DIFF
--- a/src/assembly-rewriter/Options.cs
+++ b/src/assembly-rewriter/Options.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using CommandLine;
+
+namespace AssemblyRewriter
+{
+	public class Options
+	{
+		[Option('i', "in", Min = 1, Required = true, HelpText = "input path for assembly to rewrite. Use multiple flags for multiple input paths")]
+		public IEnumerable<string> InputPaths { get; set; }
+
+		[Option('o', "out", Min = 1, Required = true, HelpText = "output path for rewritten assembly. Use multiple flags for multiple output paths")]
+		public IEnumerable<string> OutputPaths { get; set; }
+
+		[Option('r', "resolvedir", HelpText = "Additional assembly resolve directories. Use multiple flags for multiple resolve directories")]
+		public IEnumerable<string> ResolveDirectories { get; set; }
+
+		[Option('k', "keyfile", HelpText = "Sign rewritten assembly with this key file. When merge option is specified, the merged assembly will be signed.")]
+		public string KeyFile { get; set; }
+
+		[Option('m', "merge", Default = false, HelpText = "Merge all rewritten assemblies into a single assembly using the first output path as target")]
+		public bool Merge { get; set; }
+
+		[Option('v', "verbose", Default = false, HelpText = "verbose output")]
+		public bool Verbose { get; set; }
+	}
+}

--- a/src/assembly-rewriter/Program.cs
+++ b/src/assembly-rewriter/Program.cs
@@ -1,88 +1,35 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using CommandLine;
+using CommandLine.Text;
 using ILRepacking;
-using Mono.Options;
 
 namespace AssemblyRewriter
 {
 	internal static class Program
 	{
-		private static readonly List<string> InputPaths = new List<string>();
-		private static readonly List<string> OutputPaths = new List<string>();
-		private static readonly List<string> ResolveDirectories = new List<string>();
-		private static bool _merge;
-		private static string _keyFile;
-
-		private static bool _help;
-		private static bool _verbose;
-
 		private static int Main(string[] args)
 		{
-			var options = new OptionSet
+			using var parser = new Parser(settings =>
 			{
-				{
-					"i|in=", "input {path} for assembly to rewrite. Use multiple flags for multiple input paths",
-					i => InputPaths.Add(i)
-				},
-				{
-					"o|out=", "output {path} for rewritten assembly. Use multiple flags for multiple output paths",
-					o => OutputPaths.Add(o)
-				},
-				{
-					"r|resolvedir=",
-					"Additional assembly resolve directories. Use multiple flags for multiple resolve directories",
-					o => ResolveDirectories.Add(o)
-				},
-				{"m|merge", "merge all output dlls to a single dll using the first output path as target", p => _merge = p != null},
-				{"k|keyFile=", "resign merged dll with this keyFile", p => _keyFile = p},
-				{"v|verbose", "verbose output", v => _verbose = v != null},
-				{"h|?|help", "show this message and exit", h => _help = h != null}
+				settings.HelpWriter = null;
+				settings.IgnoreUnknownArguments = false;
+			});
+
+			var result = parser.ParseArguments<Options>(args);
+
+			return result switch
+			{
+				Parsed<Options> parsed => Run(parsed.Value),
+				NotParsed<Options> notParsed => HandleError(notParsed),
+				_ => 1
 			};
+		}
 
-			if (args.Length == 0)
-			{
-				ShowHelp(options);
-				return 1;
-			}
-
-			try
-			{
-				options.Parse(args);
-			}
-			catch (OptionException o)
-			{
-				Console.ForegroundColor = ConsoleColor.Red;
-				Console.WriteLine(o);
-				Console.WriteLine("Try '--help' for more information.");
-				Console.ResetColor();
-				return 1;
-			}
-
-			if (_help)
-			{
-				ShowHelp(options);
-				return 0;
-			}
-
-			if (InputPaths.Count == 0)
-			{
-				Console.ForegroundColor = ConsoleColor.Red;
-				Console.WriteLine("Must supply at least one input path using -i");
-				Console.ResetColor();
-				return 1;
-			}
-
-			if (OutputPaths.Count == 0)
-			{
-				Console.ForegroundColor = ConsoleColor.Red;
-				Console.WriteLine("Must supply at least one output path using -o");
-				Console.ResetColor();
-				return 1;
-			}
-
-			if (InputPaths.Count != OutputPaths.Count)
+		private static int Run(Options options)
+		{
+			if (options.InputPaths.Count() != options.OutputPaths.Count())
 			{
 				Console.ForegroundColor = ConsoleColor.Red;
 				Console.WriteLine("Number of input paths must equal number of output paths");
@@ -92,8 +39,8 @@ namespace AssemblyRewriter
 
 			try
 			{
-				var rewriter = new AssemblyRewriter(_verbose);
-				rewriter.RewriteNamespaces(InputPaths, OutputPaths, ResolveDirectories);
+				var rewriter = new AssemblyRewriter(options);
+				rewriter.Rewrite(options.InputPaths, options.OutputPaths, options.ResolveDirectories);
 			}
 			catch (Exception e)
 			{
@@ -101,7 +48,7 @@ namespace AssemblyRewriter
 				Console.WriteLine(e);
 				return 1;
 			}
-			if (!_merge) return 0;
+			if (!options.Merge) return 0;
 			try
 			{
 				var repackOptions = new RepackOptions
@@ -110,11 +57,11 @@ namespace AssemblyRewriter
 					Closed = true,
 					KeepOtherVersionReferences = false,
 					TargetKind = ILRepack.Kind.SameAsPrimaryAssembly,
-					InputAssemblies = OutputPaths.ToArray(),
+					InputAssemblies = options.OutputPaths.ToArray(),
 					LineIndexation = true,
-					OutputFile = OutputPaths.First(),
-					KeyFile = _keyFile,
-					SearchDirectories = OutputPaths.Select(p=> new DirectoryInfo(p).FullName).Distinct()
+					OutputFile = options.OutputPaths.First(),
+					KeyFile = options.KeyFile,
+					SearchDirectories = options.OutputPaths.Select(p=> new DirectoryInfo(p).FullName).Distinct(),
 				};
 
 				var pack = new ILRepack(repackOptions, new RepackConsoleLogger());
@@ -129,17 +76,32 @@ namespace AssemblyRewriter
 			return 0;
 		}
 
-		private static void ShowHelp(OptionSet options)
+		private static int HandleError(NotParsed<Options> notParsed)
 		{
-			Console.ForegroundColor = ConsoleColor.Green;
-			Console.WriteLine("AssemblyRewriter");
-			Console.WriteLine("----------------");
-			Console.WriteLine("Rewrites assemblies and namespaces");
-			Console.WriteLine("Options:");
-			options.WriteOptionDescriptions(Console.Out);
-			Console.WriteLine();
-			Console.WriteLine("Each input path must have a corresponding output path");
+			var helpText = HelpText.AutoBuild(notParsed, h =>
+			{
+				h.AdditionalNewLineAfterOption = false;
+				h.Heading = "AssemblyRewriter" +
+				            Environment.NewLine +
+				            "----------------" +
+				            Environment.NewLine +
+				            "Rewrites assemblies and namespaces";
+				h.AddPostOptionsLine("Each input path must have a corresponding output path");
+				return HelpText.DefaultParsingErrorsHandler(notParsed, h);
+			}, e => e);
+
+			if (notParsed.Errors.IsHelp() || notParsed.Errors.IsVersion())
+			{
+				Console.ForegroundColor = ConsoleColor.Green;
+				Console.WriteLine(helpText);
+				Console.ResetColor();
+				return 0;
+			}
+
+			Console.ForegroundColor = ConsoleColor.Red;
+			Console.WriteLine(helpText);
 			Console.ResetColor();
+			return 1;
 		}
 	}
 }

--- a/src/assembly-rewriter/Program.cs
+++ b/src/assembly-rewriter/Program.cs
@@ -15,6 +15,7 @@ namespace AssemblyRewriter
 			{
 				settings.HelpWriter = null;
 				settings.IgnoreUnknownArguments = false;
+				settings.AllowMultiInstance = true;
 			});
 
 			var result = parser.ParseArguments<Options>(args);

--- a/src/assembly-rewriter/assembly-rewriter.csproj
+++ b/src/assembly-rewriter/assembly-rewriter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>assembly-rewriter</AssemblyName>
     <RootNamespace>AssemblyRewriter</RootNamespace>
     <PackAsTool>true</PackAsTool>
@@ -18,6 +18,7 @@
 
     <Title>assembly-rewriter: a dotnet tool to rewrite assembly namespaces</Title>
     <Description>Diff assemblies and nuget packages</Description>
+    <LangVersion>latest</LangVersion>
 
   </PropertyGroup>
 
@@ -30,8 +31,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="ILRepack.Lib" Version="2.0.18" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0" />
-    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
   </ItemGroup>
 </Project>

--- a/src/assembly-rewriter/assembly-rewriter.csproj
+++ b/src/assembly-rewriter/assembly-rewriter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>assembly-rewriter</AssemblyName>
     <RootNamespace>AssemblyRewriter</RootNamespace>
     <PackAsTool>true</PackAsTool>
@@ -33,6 +33,6 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="ILRepack.Lib" Version="2.0.18" />
-    <PackageReference Include="Mono.Cecil" Version="0.10.0" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.3" />
   </ItemGroup>
 </Project>

--- a/src/assembly-rewriter/assembly-rewriter.csproj
+++ b/src/assembly-rewriter/assembly-rewriter.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
     <PackageReference Include="ILRepack.Lib" Version="2.0.18" />
     <PackageReference Include="Mono.Cecil" Version="0.11.3" />
   </ItemGroup>


### PR DESCRIPTION
This commit adds the ability to sign the rewritten assembly
when running on Full Framework. Signing is not currently
supported by Mono.Cecil on Net Core.

When a keyfile is supplied and merge is not specified (false),
the keyfile will be used to sign the rewritten assembly. When
merge is specified, the keyfile will be used to sign the merged
assembly.

Add net472 as a TargetFramework to allow signing functionality.

Move from Mono.Options to CommandLineParser as AssemblyRewriter
is signed and Mono.Options is not signed, resulting in compilation
failing when targeting net472.